### PR TITLE
chore: 修改pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm lint:fix 
+npx lint-staged 

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
   },
   "lint-staged": {
     "**/*.{ts}": [
-      "pnpm lint:fix",
-      "git add ."
+      "pnpm lint"
     ]
   },
   "license": "MIT",


### PR DESCRIPTION
现在执行git提交时，对提交的文件进行lint和格式化检查，但不会自动修改文件内容。